### PR TITLE
chore: add GitHub Actions workflow for publishing to pub.dev

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,16 @@
+# https://dart.dev/tools/pub/automated-publishing
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      # Must match the tag-pattern configured on pub.dev (e.g. v{{version}})
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write # Required for OIDC authentication with pub.dev
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    # with:
+    #   working-directory: path/to/package/within/repository


### PR DESCRIPTION
Introduced a new workflow to automate the publishing process to pub.dev, triggered by version tag pushes. This setup utilizes the dart-lang/setup-dart action for streamlined deployment.