### PR TITLE
Fix: widen analyzer constraint to support 8.x-10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.1
+
+- Widen `analyzer` constraint to `>=8.0.0 <11.0.0` so the package resolves alongside `intl_utils ^2.8.14` and modern Flutter test tooling.
+- Migrate AST scan to the renamed diagnostic API (`diagnosticCode` / `DiagnosticType`) since `errorCode` / `ErrorType` were removed in analyzer 9.0.0.
+- Raise minimum Dart SDK to `3.9.0` to match analyzer 8.x's environment constraint.
+
 ## 0.2.0
 
 - Switched from regex to AST based searching improving search time speeds by 100x.

--- a/lib/src/term_usage_ast.dart
+++ b/lib/src/term_usage_ast.dart
@@ -24,7 +24,8 @@ Set<String>? findUsedTermsWithAst(
     );
 
     final hasSyntacticError = parseResult.errors.any(
-      (error) => error.errorCode.type == ErrorType.SYNTACTIC_ERROR,
+      (diagnostic) =>
+          diagnostic.diagnosticCode.type == DiagnosticType.SYNTACTIC_ERROR,
     );
     if (hasSyntacticError) {
       return null;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "91.0.0"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
-      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
+      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.1"
+    version: "8.4.1"
   args:
     dependency: "direct main"
     description:
@@ -394,4 +394,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.9.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   args: ^2.3.1
-  analyzer: ^7.7.1
+  analyzer: ">=8.0.0 <11.0.0"
   glob: ^2.1.0
   path: ^1.8.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.0
 repository: https://github.com/Chinmay-KB/translations_cleaner
 
 environment:
-  sdk: ">=3.5.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 dependencies:
   args: ^2.3.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: translations_cleaner
 description: Package to remove unused keys in arb files, across all translations
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/Chinmay-KB/translations_cleaner
 
 environment:


### PR DESCRIPTION
## Summary
  - Bumps analyzer from ^7.7.1 to >=8.0.0 <11.0.0 so the package resolves alongside intl_utils ^2.8.14 and modern Flutter test tooling.
  - Migrates lib/src/term_usage_ast.dart to the renamed diagnostic API (diagnosticCode / DiagnosticType), since errorCode / ErrorType were removed in analyzer 9.0.0.

  Closes #19 

 ### Test plan
  - dart pub get resolves to analyzer 8.4.1
  - dart analyze clean
  - dart test — all 12 tests pass
  - Smoke-test from a Flutter project that also depends on intl_utils ^2.8.14